### PR TITLE
cliente nāo existente

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,10 @@ app.get('/extrato/:cpf', (req, res) => {
 
   const cliente = clientes.find((cliente) => cliente.cpf === cpf);
 
+  if (!cliente) {
+    return res.status(400).json({ error: 'Cliente nāo encontrado!' });
+  }
+
   return res.json(cliente.extrato);
 });
 


### PR DESCRIPTION
Se feito a busca, mas cliente nāo é cadastrado, retorna mensagem com erro.